### PR TITLE
feat: add nickname on link

### DIFF
--- a/src/main/java/de/erdbeerbaerlp/dcintegration/common/storage/Configuration.java
+++ b/src/main/java/de/erdbeerbaerlp/dcintegration/common/storage/Configuration.java
@@ -271,6 +271,9 @@ public class Configuration {
         @TomlComment({"Should discord linking be enabled?", "If whitelist is on, this can NOT be disabled", "DOES NOT WORK IN OFFLINE MODE!"})
         public boolean enableLinking = true;
 
+        @TomlComment({"Set Discord nicknames to match Minecraft usernames when linked"})
+        public boolean shouldNickname = false;
+
         @TomlComment({"Role ID of an role an player should get when he links his discord account", "Leave as 0 to disable"})
         public String linkedRoleID = "0";
 

--- a/src/main/java/de/erdbeerbaerlp/dcintegration/common/storage/PlayerLinkController.java
+++ b/src/main/java/de/erdbeerbaerlp/dcintegration/common/storage/PlayerLinkController.java
@@ -316,6 +316,8 @@ public class PlayerLinkController {
             final Member member = guild.retrieveMemberById(PlayerLinkController.getDiscordFromPlayer(UUID.fromString(link.mcPlayerUUID))).complete();
             if (linkedRole != null && !member.getRoles().contains(linkedRole))
                 guild.addRoleToMember(member, linkedRole).queue();
+            if (Configuration.instance().linking.shouldNickname)
+                member.modifyNickname(MessageUtils.getNameFromUUID(player)).queue();
             return true;
         } catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
Change discord nickname to match in-game Minecraft username when accounts are linked.

This requires additionally granting the Manage Nicknames permission on discord.