### PR TITLE
fix: slash commands not responding

### DIFF
--- a/src/main/java/de/erdbeerbaerlp/dcintegration/common/DiscordEventListener.java
+++ b/src/main/java/de/erdbeerbaerlp/dcintegration/common/DiscordEventListener.java
@@ -75,8 +75,8 @@ public class DiscordEventListener implements EventListener {
         if (event instanceof SlashCommandInteractionEvent ev) {
             if(!Configuration.instance().commands.enabled) return;
             if (ev.getChannelType().equals(ChannelType.TEXT)) {
-                if (CommandRegistry.registeredCMDs.containsKey(ev.getCommandIdLong())) {
-                    final DiscordCommand cfCommand = CommandRegistry.registeredCMDs.get(ev.getCommandIdLong());
+                if (CommandRegistry.registeredCMDs.containsKey(ev.getCommandId())) {
+                    final DiscordCommand cfCommand = CommandRegistry.registeredCMDs.get(ev.getCommandId());
                     String cmd = cfCommand.getName();
                     String args = ev.getOption("args") != null ? ev.getOption("args").getAsString() : "";
                     processDiscordCommand(ev, ArrayUtils.addAll(new String[]{cmd}, args.split(" ")), ev.getChannel(), ev.getUser(), dc);


### PR DESCRIPTION
current configured cmds are stored in a Map<String, DiscordCommand>, and we check if a slash command is valid based on whether the command id exists in the map

we're using `getCommandIdLong()` though, which returns a long instead of a String

we should use `getCommandId()` instead (which returns a String representation of the command id)