### PR TITLE
fix: get Member instance explicitly when working with reply Message objects

### DIFF
--- a/src/main/java/de/erdbeerbaerlp/dcintegration/common/DiscordEventListener.java
+++ b/src/main/java/de/erdbeerbaerlp/dcintegration/common/DiscordEventListener.java
@@ -15,6 +15,7 @@ import dev.vankka.simpleast.core.parser.ParseSpec;
 import dev.vankka.simpleast.core.parser.Parser;
 import dev.vankka.simpleast.core.parser.Rule;
 import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.User;
@@ -156,11 +157,13 @@ public class DiscordEventListener implements EventListener {
                         final TextReplacementConfig userReplacer = ComponentUtils.replaceLiteral("%user%", user);
                         out = out.replaceText(userReplacer).replaceText(idReplacer).replaceText(msgReplacer);
                         if (hasReply) {
+                            Member replyMember = reply.isWebhookMessage() ? null : dc.getMemberById(reply.getAuthor().getIdLong());
+
                             memberStyle = Style.style();
                             if (Configuration.instance().messages.discordRoleColorIngame)
-                                memberStyle = memberStyle.color(TextColor.color((reply.getMember() != null ? reply.getMember().getColorRaw() : 0)));
-                            final Component repUser = Component.text((reply.getMember() != null ? reply.getMember().getEffectiveName() : reply.getAuthor().getName()))
-                                    .style(ComponentUtils.addUserHoverClick(memberStyle.build(), reply.getAuthor(), reply.getMember()));
+                                memberStyle = memberStyle.color(TextColor.color((replyMember != null ? replyMember.getColorRaw() : 0)));
+                            final Component repUser = Component.text((replyMember != null ? replyMember.getEffectiveName() : reply.getAuthor().getName()))
+                                    .style(ComponentUtils.addUserHoverClick(memberStyle.build(), reply.getAuthor(), replyMember));
                             out = out.replaceText(ComponentUtils.replaceLiteral("%ruser%", repUser));
                             final String repMsg = MessageUtils.formatEmoteMessage(reply.getMentions().getCustomEmojis(), reply.getContentDisplay());
                             @SuppressWarnings("unchecked") final Component replyMsg = MinecraftSerializer.INSTANCE.serialize(repMsg.replace("\n", "\\n"), mcSerializerOptions);


### PR DESCRIPTION
(this fixes role color/server nicknames not showing up when referring to the authors of replied-to messages)

the Message object returned by `Message.getReferencedMessage()` seems to not have the `Member` field populated, so `getMember()` always returns null and the authors of replied-to messages always show up as the default role color (which is black in this case)

possibly related to https://github.com/discord/discord-api-docs/discussions/3258

to fix this, get the Member object from the member cache then work with that instead