### PR TITLE
Move all forking Threads to daemon worker thread.

### DIFF
--- a/src/main/java/de/erdbeerbaerlp/dcintegration/common/WorkThread.java
+++ b/src/main/java/de/erdbeerbaerlp/dcintegration/common/WorkThread.java
@@ -1,0 +1,141 @@
+package de.erdbeerbaerlp.dcintegration.common;
+
+import java.util.LinkedList;
+import java.util.Optional;
+import java.util.concurrent.locks.LockSupport;
+import java.util.function.Supplier;
+
+/// Simple Off-ServerThread task executor
+public final class WorkThread {
+    private WorkThread() {} // static class
+
+    private static final LinkedList<Job> jobQueue = new LinkedList<>();
+    private static final Thread runner = do_start(new Thread(WorkThread::thread, "DiscordIntegration-Core WorkerThread"));
+    private static Thread do_start(Thread thr) {
+        thr.setDaemon(true); // mark as background thread
+        thr.start();
+        return thr;
+    }
+
+    private static void thread() {
+        while(true) {
+            { // this stack frame solely exists to allow j to be discarded
+                Job j;
+                while ((j = jobQueue.poll()) != null) {
+                    j.run();
+                }
+            }
+            LockSupport.park();
+        }
+    }
+    private static void pushJob(Job job) {
+
+        // Note if you experience very delayed execution of tasks
+        //  remove the unpark variable checks, and just call
+        //      LockSupport.unpark(runner);
+        //  everytime
+
+        boolean unpark = jobQueue.isEmpty();
+        jobQueue.addLast(job);
+        unpark = unpark || jobQueue.peekLast() == jobQueue.peekFirst();
+        if (unpark)
+            LockSupport.unpark(runner);
+    }
+
+
+    /// adds an execution job to the WorkThread, if executing under the WorkThread already the job is syncronously executed
+    public static JobHandle executeJob(Runnable action) {
+        final class JobAction implements Job {
+            public JobAction(Runnable action, JobHandle handle) {
+                this.action = action;
+                this.handle = handle;
+            }
+            final Runnable action;
+            final JobHandle handle;
+            public void run() {
+                try {
+                    this.action.run();
+                } catch (Exception ex) {
+                    this.handle.error = ex;
+                }
+                this.handle.completed = true;
+            }
+        }
+
+        JobHandle handle = new JobHandle();
+        JobAction job = new JobAction(action, handle);
+
+        if (Thread.currentThread() == runner) {
+            job.run();
+        }
+        else {
+            pushJob(job);
+        }
+
+        return handle;
+    }
+
+    /// adds an execution job to the WorkThread, if executing under the WorkThread already the job is syncronously executed
+    public static <R>JobHandleWithResult<R> executeJobWithReturn (Supplier<R> action) {
+        final class JobActionWithReturn implements Job {
+            public JobActionWithReturn(Supplier<R> action, JobHandleWithResult<R> handle) {
+                this.action = action;
+                this.handle = handle;
+            }
+            final Supplier<R> action;
+            final JobHandleWithResult<R> handle;
+            public void run() {
+                try {
+                    this.handle.result = this.action.get();
+                } catch (Exception ex) {
+                    this.handle.error = ex;
+                }
+                this.handle.completed = true;
+            }
+        }
+
+
+        JobHandleWithResult<R> handle = new JobHandleWithResult<>();
+        JobActionWithReturn job = new JobActionWithReturn(action, handle);
+
+
+        if (Thread.currentThread() == runner) {
+            job.run();
+        }
+        else {
+            pushJob(job);
+        }
+
+        return handle;
+    }
+
+
+    public static class JobHandleWithResult<R> {
+        private Boolean completed;
+        private Exception error = null;
+        private R result;
+
+        public Boolean isCompleted() {
+            return this.completed;
+        }
+        public Optional<Exception> getError() {
+            return Optional.ofNullable(this.error);
+        }
+        public Optional<R> getResult() {
+            return Optional.ofNullable(this.result);
+        }
+    }
+    public static class JobHandle {
+        private Boolean completed = false;
+        private Exception error = null;
+        public Boolean isCompleted() {
+            return this.completed;
+        }
+        public Optional<Exception> getError() {
+            return Optional.ofNullable(this.error);
+        }
+    }
+    private interface Job {
+        void run();
+    }
+}

--- a/src/main/java/de/erdbeerbaerlp/dcintegration/common/util/UpdateChecker.java
+++ b/src/main/java/de/erdbeerbaerlp/dcintegration/common/util/UpdateChecker.java
@@ -3,6 +3,7 @@ package de.erdbeerbaerlp.dcintegration.common.util;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import de.erdbeerbaerlp.dcintegration.common.WorkThread;
 import de.erdbeerbaerlp.dcintegration.common.storage.Configuration;
 
 import java.io.IOException;
@@ -21,7 +22,7 @@ public class UpdateChecker {
      */
     public static void runUpdateCheck(String url) {
         if (!Configuration.instance().general.enableUpdateChecker) return;
-        final Thread thread = new Thread(() -> {
+        WorkThread.executeJob(() -> {
             final StringBuilder changelog = new StringBuilder();
             try {
                 final HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
@@ -61,10 +62,6 @@ public class UpdateChecker {
                 e.printStackTrace();
             }
         });
-        thread.setDaemon(true);
-        thread.setName("Discord Integration - Update checker");
-        thread.start();
-
     }
 
     /**


### PR DESCRIPTION
Constantly creating new threads is costly, thus I have implemented a generic WorkThread implementation.
Use this class whenever you want to move work off-thread as it does not inquire the costs of allocating and creating a new thread.

Replaced all instances of empty string concatenation, to change types, into String.valueOf(*).