### PR TITLE
Add support for #RRGGBB hex colour values for embed

### DIFF
--- a/src/main/java/de/erdbeerbaerlp/dcintegration/common/storage/Configuration.java
+++ b/src/main/java/de/erdbeerbaerlp/dcintegration/common/storage/Configuration.java
@@ -12,6 +12,9 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 
 import java.awt.*;
 import java.io.IOException;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+
 
 import static de.erdbeerbaerlp.dcintegration.common.DiscordIntegration.configFile;
 
@@ -234,9 +237,27 @@ public class Configuration {
             }
 
             public EmbedBuilder toEmbedJson(String jsonString) {
-                final DataObject json = DataObject.fromJson(jsonString);
+                final DataObject json = DataObject.fromJson(jsonColorHexToDec(jsonString));
                 return EmbedBuilder.fromData(json);
             }
+        }
+
+            private String jsonColorHexToDec(String inputString) {
+            
+                Pattern pattern = Pattern.compile("\\\"color\\\": \\\"#[A-Za-z0-9]{6}");
+                Matcher matcher = pattern.matcher(inputString);
+                StringBuilder sb = new StringBuilder();
+                
+                if (matcher.find()) {
+                    String extractedString = matcher.group(0);
+                  	String colorInHex = extractedString.substring(extractedString.indexOf("#") + 1);
+                  	String replacmentStr = extractedString.replace(colorInHex, String.valueOf(Integer.parseInt(colorInHex, 16))).replace("#", "");
+                    matcher.appendReplacement(sb, replacmentStr);
+                    matcher.appendTail(sb);
+                    String outputString = sb.toString();
+                    return outputString;
+                }
+                return inputString;
         }
 
         public static class ChatEmbedEntry extends EmbedEntry {


### PR DESCRIPTION
The [embed creator](https://embed.dan.onl/) I initially used gave hex rather than the decimal representation, this function checks against a quick regex to see if #RRGGBB hex value has been used and if so converts it to decimal and returns the string as normal.  

Example:  
```
jsonColorHexToDec("{\r\n  \"author\": {\r\n    \"name\": \"%name%\",\r\n    \"icon_url\": \"https://crafthead.net/avatar/%uuid%\"\r\n  },\r\n  \"description\": \"%msg%\",\r\n  \"color\": \"#4F545C\"\r\n}")
```  

gives: 
```
{\r\n  \"author\": {\r\n    \"name\": \"%name%\",\r\n    \"icon_url\": \"https://crafthead.net/avatar/%uuid%\"\r\n  },\r\n  \"description\": \"%msg%\",\r\n  \"color\": \"5198940\"\r\n}
```  

And if decimal is given originally, no changes are made.
Currently if a Hex value #RRGGBB is given the following crash error is given:
```
java.lang.NumberFormatException: For input string: "#4F545C"
        at java.base/java.lang.NumberFormatException.forInputString(Unknown Source) ~[?:?]
        at java.base/java.lang.Integer.parseInt(Unknown Source) ~[?:?]
        at java.base/java.lang.Integer.parseInt(Unknown Source) ~[?:?]
        at knot/net.dv8tion.jda.api.utils.data.DataObject.get(DataObject.java:913) ~[de_erdbeerbaerlp_dcintegration_common-3.1.0-55dc154341f71a65.jar:?]
        at knot/net.dv8tion.jda.api.utils.data.DataObject.getInt(DataObject.java:575) ~[de_erdbeerbaerlp_dcintegration_common-3.1.0-55dc154341f71a65.jar:?]
        at knot/net.dv8tion.jda.api.EmbedBuilder.fromData(EmbedBuilder.java:115) ~[de_erdbeerbaerlp_dcintegration_common-3.1.0-55dc154341f71a65.jar:?]
        at knot/de.erdbeerbaerlp.dcintegration.common.storage.Configuration$EmbedMode$EmbedEntry.toEmbedJson(Configuration.java:238) ~[de_erdbeerbaerlp_dcintegration_common-3.1.0-55dc154341f71a65.jar:?]
```  
The above function would prevent this, and also may be altered for formats of 0xRRGGBB along with #RRGGBB as needed.  

##### ps, the function itself is tested standalone- but has not been integration tested  