### PR TITLE
Add %texture_hash% to API test

### DIFF
--- a/src/main/java/de/erdbeerbaerlp/dcintegration/common/storage/Configuration.java
+++ b/src/main/java/de/erdbeerbaerlp/dcintegration/common/storage/Configuration.java
@@ -350,7 +350,7 @@ public class Configuration {
         public boolean useServerNameForRcon = true;
         @TomlComment("Use the server name and avatar for Console")
         public boolean useServerNameForConsole = true;
-        @TomlComment({"The URL where the player avatar gets fetched from", "", "PLACEHOLDERS:", "%uuid% - Returns the player's UUID with dashes", "%uuid_dashless% - Returns the player's UUID without dashes", "%name% - Returns the player's name", "%randomUUID% - Returns an random UUID which can be used to prevent discord cache", "https://www.tydiumcraft.net/docs/skinapi supports both bedrock(floodgate) and java players", "Default - https://starlightskins.lunareclipse.studio/render/pixel/%name%/face?randomuuid=%randomUUID%"})
+        @TomlComment({"The URL where the player avatar gets fetched from", "", "PLACEHOLDERS:", "%uuid% - Returns the player's UUID with dashes", "%uuid_dashless% - Returns the player's UUID without dashes", "%name% - Returns the player's name", "%texture_hash% - Returns player's skin texture ID (hash)", "%randomUUID% - Returns an random UUID which can be used to prevent discord cache", "https://www.tydiumcraft.net/docs/skinapi supports both bedrock(floodgate) and java players", "Default - https://starlightskins.lunareclipse.studio/render/pixel/%name%/face?randomuuid=%randomUUID%"})
         public String playerAvatarURL = "https://starlightskins.lunareclipse.studio/render/pixel/%name%/face?randomuuid=%randomUUID%";
         @TomlComment({"Should the avatar url be tested periodically?","If enabled, should the avatar url be down, it will use the fallback one until it comes back"})
         public boolean testAvatarURL = true;

--- a/src/main/java/de/erdbeerbaerlp/dcintegration/common/threads/APITestTask.java
+++ b/src/main/java/de/erdbeerbaerlp/dcintegration/common/threads/APITestTask.java
@@ -16,6 +16,7 @@ public class APITestTask extends TimerTask {
     // == Values used for testing the URL
     private static final UUID testUUID = UUID.fromString("210f7275-c79f-44f8-a7a0-7da71c751bb9");
     private static final String testName = "ErdbeerbaerLP";
+    private static final String testTexture = "fb057682288b5948a099d41348b35672b4e2af280bcc2b1a8df665f5d3f0aa64";
     // ==
 
     public APITestTask(final DiscordIntegration dc) {
@@ -24,7 +25,7 @@ public class APITestTask extends TimerTask {
 
     @Override
     public void run() {
-        final String urlToTest = Configuration.instance().webhook.playerAvatarURL.replace("%uuid%", testUUID.toString()).replace("%uuid_dashless%", testUUID.toString().replace("-", "")).replace("%name%", testName).replace("%randomUUID%", UUID.randomUUID().toString());
+        final String urlToTest = Configuration.instance().webhook.playerAvatarURL.replace("%uuid%", testUUID.toString()).replace("%uuid_dashless%", testUUID.toString().replace("-", "")).replace("%name%", testName).replace("%randomUUID%", UUID.randomUUID().toString()).replace("%texture_hash%", testTexture);
         try {
             final HttpURLConnection c = (HttpURLConnection) new URL(urlToTest).openConnection();
             c.connect();


### PR DESCRIPTION
Correlates with the PR for introducing `%texture_hash%`, adding it as part of the skin api availability check.