### PR TITLE
Optional message suppression

### DIFF
--- a/src/main/java/de/erdbeerbaerlp/dcintegration/common/storage/Configuration.java
+++ b/src/main/java/de/erdbeerbaerlp/dcintegration/common/storage/Configuration.java
@@ -311,6 +311,12 @@ public class Configuration {
         public String baseAPIUrl = "https://discord.com";
         @TomlComment({"Delay of sending webhook messages ingame in milliseconds", "If you get duplicate messages in webhook mode, increase this value a bit"})
         public long webhookMessageDelay = 200;
+
+        @TomlComment({"Sends chat messages relayed from Minecraft with the 'Suppress Notifications' flag, also known as \"@silent\""})
+        public boolean suppressDiscordNotificationsFromChat;
+
+        @TomlComment({"Sends server, death and advancement messages with the 'Suppress Notifications' flag, also known as \"@silent\""})
+        public boolean suppressDiscordNotificationsFromSystem;
     }
 
     public static class ForgeSpecific {

--- a/src/main/java/de/erdbeerbaerlp/dcintegration/common/util/DiscordMessage.java
+++ b/src/main/java/de/erdbeerbaerlp/dcintegration/common/util/DiscordMessage.java
@@ -158,6 +158,12 @@ public final class DiscordMessage {
             out.setEmbeds(embed);
 
         }
+        if (isSystemMessage && Configuration.instance().advanced.suppressDiscordNotificationsFromSystem) {
+            out.setSuppressedNotifications(true);
+        }
+        if (!isSystemMessage && Configuration.instance().advanced.suppressDiscordNotificationsFromChat) {
+            out.setSuppressedNotifications(true);
+        }
         return out.build();
     }
 


### PR DESCRIPTION
Adds notification suppression to the configuration config, then sets it according to the isSystemMessage variable.

This is already implemented by the library being used to interact with Discord, so it's just a matter of calling `setSuppressedNotifications(true)`.

Configuration was added for this in the Configuration.java file.